### PR TITLE
Some improvements to gpu_max_load.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ notes
 nohup.out
 results*
 __pycache__
+.idea

--- a/gpu_max_load.py
+++ b/gpu_max_load.py
@@ -1,7 +1,7 @@
 """
 Description: This code performs intensive GPU loading by repeatedly executing matrix multiplication
 on large random matrices using PyTorch. Each GPU specified in the list is loaded with heavy 
-computation in a separate process, utilizing the multiprocessing module. The script aims to stress 
+computation in a separate process, utilizing the torch.multiprocessing module. The script aims to stress
 test the GPUs by continuously performing operations that demand significant computational power.
 
 Author: TheDataDaddi
@@ -10,38 +10,192 @@ Version: 1.0
 License: MIT License
 """
 
-
+import time
 import torch
-from multiprocessing import Process
+import argparse
+import threading
+import multiprocessing
+import queue
+import torch.multiprocessing as mp
 
-# Function to load a specific GPU with heavy computation
-def load_gpu(gpu_id):
+from typing import Any
+
+
+# global state for threads (do not modify)
+run_ctx = {
+    't_start': 0.0,  # time when test started
+    'dt_stress': 0.0,  # duration of the test
+    'flag_start': False,  # set to true when stress test is started
+    'flag_stop': False,  # set to true when stress test must stop
+}
+
+
+def load_gpu(
+        gpu_id: int,
+        q_in: multiprocessing.Queue,
+        q_out: multiprocessing.Queue,
+        n: int = 10000,
+        t_max: float = 3600 * 8
+):
+    """Load a specific GPU with heavy computation."""
+    assert gpu_id >= 0, 'GPU ID must be a positive integer.'
+    t0 = time.time()
     # Set the device to the specified GPU
     device = torch.device(f'cuda:{gpu_id}')
     
     # Create large random matrices
-    matrix1 = torch.randn(10000, 10000, device=device)
-    matrix2 = torch.randn(10000, 10000, device=device)
+    matrix1 = torch.randn(n, n, device=device)
+    matrix2 = torch.randn(n, n, device=device)
 
-    # Perform matrix multiplication repeatedly to load the GPU
+    count_matmul = 0
+    dt_count = 5.0
+    t_cur = time.time()
+    t_ops0 = t_cur
+    try:
+        # Perform matrix multiplication repeatedly to load the GPU
+        while t_cur - t0 < t_max:
+            try:
+                data = q_in.get(False)
+            except queue.Empty:
+                pass
+            else:
+                if data == 'STOP':
+                    break
+            if t_cur - t_ops0 >= dt_count:
+                matmul_per_second = count_matmul / (time.time() - t_ops0)
+                count_matmul = 0
+                t_ops0 = time.time()
+                q_out.put(f'load_gpu(gpu_id:{gpu_id}), M1({n}:{n}) x M2({n}:{n}), matmul_per_second={matmul_per_second:.2f}')
+
+            _ = torch.matmul(matrix1, matrix2)
+            count_matmul += 1
+            t_cur = time.time()
+    except KeyboardInterrupt:
+        print('KeyboardInterrupt Exception received inside load_gpu process. Exiting GPU load.')
+
+
+def get_num_gpus() -> int:
+    """How many cuda devices are available?"""
+    return torch.cuda.device_count()
+
+
+def list_gpu_properties(output: str = 'str') -> str | list[(int, Any)]:
+    """List properties of all available cuda GPUs."""
+    l = [(i, torch.cuda.get_device_properties(i)) for i in range(torch.cuda.device_count())]
+    return '\n'.join(['#device#\t#properties#'] + [f'cuda:{i}\t\t{p}' for i, p in l]) if output == 'str' else l
+
+
+def list_gpu_running_state(gpu_id_list: list[int]):
+    """List the running state of each GPU in the list. This includes: Temperature, Memory Usage, and Power Usage."""
+    if not run_ctx['flag_start']:
+        print('GPU state before stress test started:')
+    else:
+        t_remaining = run_ctx['t_start'] + run_ctx['dt_stress'] - time.time()
+        print(f'GPU state after stress test started -- stress time remaining {t_remaining:.2f} secs: {time.strftime("%H:%M:%S", time.gmtime(t_remaining))}')
+    for gpu_id in gpu_id_list:
+        print(f'GPU cuda:{gpu_id} - {torch.cuda.get_device_name(gpu_id)}')
+        device = torch.device(f'cuda:{gpu_id}')
+
+        gpu_temperature = torch.cuda.temperature(device)
+        gpu_power_draw = torch.cuda.power_draw(device)  # average power draw in mW (MilliWatts)
+
+        print(f"GPU Temperature: {gpu_temperature}°C")
+        print(f"GPU Power Draw: {gpu_power_draw / 1000} W")
+
+        free, total = torch.cuda.mem_get_info(device)
+
+        print('Memory Usage:')
+        print('Allocated:', round((total - free) / 1024 ** 3, 1), 'GB')
+        print('Total:   ', round(total / 1024 ** 3, 1), 'GB')
+        print('\n')
+
+
+def report_loop(gpu_id_list: list[int], q_out: multiprocessing.Queue, t_sleep: float = 10):
+    """Report GPU load every t_sleep seconds."""
+    while not run_ctx['flag_stop'] and run_ctx['t_start'] + run_ctx['dt_stress'] > time.time():
+        list_gpu_running_state(gpu_id_list)
+        print_messages_from_queue(q_out)
+        time.sleep(t_sleep)
+
+
+def print_messages_from_queue(q_out: multiprocessing.Queue):
+    out = ['Now reporting messages from load_gpu Processes:', ]
     while True:
-        _ = torch.matmul(matrix1, matrix2)
+        try:
+            msg = q_out.get(False)
+            out.append(str(msg))
+        except queue.Empty:
+            break
+    if len(out) > 1:
+        print('\n'.join(out) + '\n')
 
-if __name__ == '__main__':
+
+def send_stop_signal(gpu_id_list: list[int], q: multiprocessing.Queue):
+    """Send a stop signal to the queue."""
+    run_ctx['flag_stop'] = True
+    for i in range(len(gpu_id_list)):
+        q.put('STOP')
+
+
+def cli():
+    """Command line interface for the script."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-t', type=int, default=120, help='Time in seconds to run the GPU load. (Default: 120 secs).')
+    parser.add_argument('-n', type=int, default=10000, help='Num of rows in the square matrix with which to perform matrix multiplication. Matrix will have dimensions (n x n). (Default: 10000).')
+    return parser.parse_args()
+
+
+def main():
+    """Main function to run the script."""
+    args = cli()
+
+    print(f'List of GPUs:\n{list_gpu_properties()}\n')
+
     # List of GPU IDs to load
-    gpu_id_list = [0, 1]
+    gpu_id_list = list(range(0, get_num_gpus()))  # [0, 1]
 
+    list_gpu_running_state(gpu_id_list)
+
+    print(f'>> Initiating run of max load GPU for {args.t} seconds...\n\n')
+
+    mp.set_start_method('spawn')
+
+    t_start = run_ctx['t_start'] = time.time()
+    dt_stress = run_ctx['dt_stress'] = args.t
+    flag_stop = run_ctx['flag_stop'] = False
+    run_ctx['flag_start'] = True
+
+    q_in = mp.Queue()
+    q_out = mp.Queue()
     processes = []
 
     # Load each GPU in a separate process
     for id_ in gpu_id_list:
         # Create a new process for each GPU
-        p = Process(target=load_gpu, args=(id_,))
+        p = mp.Process(target=load_gpu, args=(id_, q_in, q_out, args.n, args.t))
         # Start the process
         p.start()
         # Add the process to the list of processes
         processes.append(p)
 
-    # Join all processes
+    t_report = threading.Thread(target=report_loop, args=(gpu_id_list, q_out, 5))
+    t_report.start()
+
+    try:
+        while not flag_stop and t_start + dt_stress > time.time():
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        print('\nStopping stress test by user request. Please wait for the processes to finish. This may take a while.')
+    send_stop_signal(gpu_id_list, q_in)
+
+    # join report threads and wait for it to finish
+    t_report.join()
+    # Join all processes to wait until they finish
     for p in processes:
         p.join()
+
+    print('<< Done stressing GPUs!')
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,3 +91,4 @@ wheel==0.41.2
 xxhash==3.4.1
 yarl==1.9.4
 zipp==3.17.0
+pynvml==11.5.3


### PR DESCRIPTION
Hey!

Thanks for contributing your code in this repo. I am starting my journey as a home lab AI aficionado and I was surprised not to find more projects providing benchmarks for comparing performance of graphic cards in common AI tasks.

Anyway, I plan to use your code to stress test a GPU I got to see if it does not overheat and if the memory allocation works well, and I think your `gpu_max_load.py ` script is what I need.

In the course of testing the script I found a couple of things that I thought might be improvements:

1. Add a minimal argparse cli for info and modifying the size of the matrix and time to run stress test.
2. Switched from using `multiprocessing. Process` to `torch.multiprocessing.Process` in order to avoid an error that appeared after I ran the script more than one time, something like: "Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method".
3. Cleaner exit messages when user hits Ctrl-C
4. Added a small report thread that periodically (every 5 secs) outputs info about the card, example:

```
GPU state after stress test started -- stress time remaining 199.78 secs: 00:03:19
GPU cuda:0 - NVIDIA GeForce RTX 4070 Ti SUPER
GPU Temperature: 73°C
GPU Power Draw: 284.426 W
Memory Usage:
Allocated: 6.9 GB
Total:    15.7 GB
``` 

5. Added also: each load_gpu process reports back to the main process how many multiplications per second are being done, example:

```
Now reporting messages from load_gpu Processes:
load_gpu(gpu_id:0), M1(10000:10000) x M2(10000:10000), matmul_per_second=13.26
``` 

Let me know if you like this PR is good, or if there is something I should improve. Or if you think it's no use to your project no worries either :)

Cheers
